### PR TITLE
Fix issue with checking wrong path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,26 @@
 use directories::ProjectDirs;
-use iced::Length::Fill;
-use iced::border::Radius;
-use iced::widget::button::Style as ButtonStyle;
-use iced::widget::text::Style as TextStyle;
-use iced::widget::{Container, button, column, container, row, text, text_input};
-use iced::{Border, Color, Element, Font, Task};
+use iced::{
+    Border, Color, Element, Font,
+    Length::{self, Fill},
+    Task,
+    border::Radius,
+    widget::{
+        button, button::Style as ButtonStyle, column, container, radio, row, text,
+        text::Style as TextStyle, text_input,
+    },
+};
 use serde::{Deserialize, Serialize};
-use std::fs::{self};
-use std::io::Write;
-use std::path::PathBuf;
+use std::{
+    fs::{self, File},
+    io::Write,
+};
 
 #[derive(Serialize, Deserialize, Default, Clone)]
 struct Flashcard {
     question: String,
     answers: [String; 4],
-    correct_question: usize, // could be i32 but usize is not negative
-    image: Option<String>,   // path
+    correct_question: usize,
+    image: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -35,17 +40,38 @@ enum Message {
     ChangeTitle(String),
     ChangeContent(String),
     ChangeImageString(Option<String>),
+    ChangeNewAnswer(String),
+    AddAnswer,
+    ChangeQuestion(String),
+    ChangeAnswer(usize, String),
+    RemoveAnswer(usize),
+    SelectCorrect(usize),
+    SubmitFlashcard,
 }
 
 struct App {
     menu_state: Menu,
     flashcards: Vec<Flashcard>,
     project_dir: ProjectDirs,
-    config: PathBuf,
+    new_question: String,
+    new_answer: String,
+    new_answers: Vec<String>,
+    new_correct_index: Option<usize>,
+    new_image: Option<String>,
 }
 
 const WINDOW_WIDTH: f32 = 800.0;
 const WINDOW_HEIGHT: f32 = 400.0;
+
+macro_rules! full_centered {
+    ($child:expr) => {
+        container($child)
+            .width(Fill)
+            .height(Fill)
+            .center_x(Fill)
+            .center_y(Fill)
+    };
+}
 
 impl Default for App {
     fn default() -> Self {
@@ -54,22 +80,30 @@ impl Default for App {
         let config_path = dirs.config_dir();
         let config_file = config_path.join("flashcards.json");
 
-        if !config_path.exists() {
+        if !config_file.exists() {
             std::fs::create_dir_all(config_path).unwrap();
 
-            let mut file = std::fs::File::create(&config_file).unwrap();
-            file.write_all(b"{}").unwrap();
+            let mut file = File::create(&config_file).expect("writing failed");
+
+            // properly format the default flashcard JSON
+            let default = vec![Flashcard::default()];
+            let default_contents = serde_json::to_string_pretty(&default).unwrap();
+
+            file.write_all(default_contents.as_bytes()).unwrap();
         }
 
         let read = fs::read_to_string(&config_file).unwrap();
-
         let flashcard_struct: Vec<Flashcard> = serde_json::from_str(read.as_str()).unwrap();
 
         App {
             project_dir: dirs,
             menu_state: Menu::Main,
             flashcards: flashcard_struct,
-            config: config_file,
+            new_question: String::new(),
+            new_answer: String::new(),
+            new_answers: Vec::new(),
+            new_correct_index: None,
+            new_image: None,
         }
     }
 }
@@ -92,8 +126,6 @@ impl App {
             ..Default::default()
         };
 
-        let a_row = row![];
-
         let c = match self.menu_state {
             Menu::Main => container(column![
                 text("Flash")
@@ -113,13 +145,69 @@ impl App {
                         .padding(25)
                 ]
             ]),
-            Menu::CreateFlashcard => container(row![
-                // text_input().on_input(Message::)
-                button(text("Add Answer")).on_press(),
-            ]),
-            //button(text("Back")).on_press(Message::Back)
+            Menu::CreateFlashcard => {
+                let mut answer_section = column![].spacing(10);
+
+                for (idx, answer) in self.new_answers.iter().enumerate() {
+                    let remove_button = if self.new_answers.len() > 2 {
+                        button("Remove flashcard").on_press(Message::RemoveAnswer(idx))
+                    } else {
+                        button("Remove flashcard").padding(5)
+                    };
+
+                    answer_section = answer_section.push(row![
+                        text_input(&format!("Answer {}", idx + 1), answer)
+                            .on_input(move |s| Message::ChangeAnswer(idx, s))
+                            .padding(5)
+                            .width(Fill),
+                        remove_button,
+                        radio("Correct", idx, self.new_correct_index, move |_| {
+                            Message::SelectCorrect(idx)
+                        })
+                    ]);
+                }
+
+                if self.new_answers.len() < 4 {
+                    answer_section = answer_section.push(row![
+                        text_input("Add answer…", &self.new_answer)
+                            .on_input(Message::ChangeNewAnswer)
+                            .on_submit(Message::AddAnswer)
+                            .padding(5)
+                            .width(Fill),
+                        button("+")
+                            .on_press_maybe(
+                                (!self.new_answer.trim().is_empty() && self.new_answers.len() < 4)
+                                    .then(|| Message::AddAnswer)
+                            )
+                            .padding(5),
+                    ]);
+                }
+
+                let form_complete = !self.new_question.trim().is_empty()
+                    && self.new_answers.len() >= 2
+                    && self.new_correct_index.is_some();
+
+                let save_button = button("Save Flashcard")
+                    .on_press_maybe(form_complete.then(|| Message::SubmitFlashcard))
+                    .padding(10)
+                    .width(Length::Fixed(200.0));
+
+                let content = column![
+                    text_input("Question…", &self.new_question)
+                        .on_input(Message::ChangeQuestion)
+                        .padding(5)
+                        .width(Fill),
+                    answer_section,
+                    save_button,
+                ]
+                .spacing(20)
+                .padding(20)
+                .max_width(600);
+
+                container(content)
+            }
         };
-        container(c).width(Fill).center(Fill).into()
+        full_centered!(c).into()
     }
 
     fn update(&mut self, message: Message) -> Task<Message> {
@@ -129,29 +217,58 @@ impl App {
             }
             Message::Back => {
                 self.menu_state = Menu::Main;
+
+                // Reset creation state
+                self.new_question.clear();
+                self.new_answer.clear();
+                self.new_answers.clear();
+                self.new_correct_index = None;
+                self.new_image = None;
             }
             Message::Add(question, answers, correct_question, image) => {
-                let file_contents = std::fs::read_to_string(&self.config).unwrap();
+                let config_path = self.project_dir.config_dir().join("flashcards.json");
+                let file_contents = fs::read_to_string(&config_path).unwrap();
 
                 let data: Vec<Flashcard> = serde_json::from_str(&file_contents).unwrap();
 
                 self.flashcards = data;
 
                 let flashcard = Flashcard {
-                    question: question,
-                    answers: answers,
-                    correct_question: correct_question,
-                    image: image,
+                    question,
+                    answers,
+                    correct_question,
+                    image,
                 };
 
                 self.flashcards.push(flashcard.clone());
 
                 let updated_cards = serde_json::to_string_pretty(&self.flashcards).unwrap();
 
-                let _ = std::fs::write(&self.config, updated_cards.as_bytes());
+                fs::write(config_path, updated_cards.as_bytes()).unwrap();
             }
-            Message::Remove => {}
+            Message::ChangeTitle(s) => {
+                self.new_question = s;
+            }
+            Message::ChangeContent(s) => {
+                self.new_answer = s;
+            }
+            Message::ChangeImageString(s) => {
+                self.new_image = s;
+            }
+            Message::AddAnswer => {
+                if self.new_answers.len() < 4 && !self.new_answer.is_empty() {
+                    self.new_answers.push(self.new_answer.clone());
+                    self.new_answer.clear();
+                }
+            }
+            Message::SelectCorrect(index) => {
+                if index < self.new_answers.len() {
+                    self.new_correct_index = Some(index);
+                }
+            }
             Message::Cycle => {}
+            Message::Remove => {}
+            _ => todo!(),
         }
 
         Task::none()


### PR DESCRIPTION
The flashcard creation menu UI was created, but the implementation is left empty.

Summary of changes:

- Add new fields to the `App` struct for managing the creation state of a flashcard.
- Add a `full_centered` macro to center the content within the container.
- Complete the CreateFlashcard menu to show the UI with input fields.
- Update the `update` method to handle messages related to flashcard creation.
- Update the `default` method to initialize the new creation state fields.
- Fix panic where Iced would incorrectly check the config folder, and not the file.